### PR TITLE
Bump `impl(ghc)` bounds in `generically.cabal`

### DIFF
--- a/generically.cabal
+++ b/generically.cabal
@@ -35,7 +35,7 @@ source-repository head
 library
   default-language: Haskell2010
   build-depends:    base >=4.9 && <4.19
-  if impl(ghc >= 9.4) && !impl(ghc >= 9.6)
+  if impl(ghc >= 9.4) && !impl(ghc >= 9.8)
     build-depends:  base-orphans >=0.8.8 && <0.10
   hs-source-dirs:   src
   exposed-modules:  GHC.Generics.Generically


### PR DESCRIPTION
This enables building with GHC 9.6.